### PR TITLE
Fix EBNF for FuncDecl in mandelbrot

### DIFF
--- a/mandelbrot/README.md
+++ b/mandelbrot/README.md
@@ -8,7 +8,7 @@ Your SysY compiler must support the following "function declaration" syntax:
 
 ```ebnf
 FuncDef ::= FuncType IDENT "(" [FuncFParams] ")" Block;
-FuncDecl ::= FuncType IDENT "(" [FuncFParams] ")";
+FuncDecl ::= FuncType IDENT "(" [FuncFParams] ")" ";";
 ```
 
 To get an executable, you should link the SysY compiler-generated file with `libsysy` and `fp-math.c`.


### PR DESCRIPTION
This is coherent with [the EBNF in the tutorial](https://pku-minic.github.io/online-doc/#/lv9p-reincarnation/awesome-compiler?id=mandelbrot) and the program itself.